### PR TITLE
form.item如果设置了labelSize,但是select内容宽度很长时,样式错乱

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nek-ui",
   "description": "UI components based on RegularJS",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "./dist/js/nek-ui.js",
   "homepage": "https://nek-ui.kaolafed.com/",
   "license": "MIT",

--- a/src/js/components/form/KLForm/KLFormItem/index.mcss
+++ b/src/js/components/form/KLForm/KLFormItem/index.mcss
@@ -34,9 +34,9 @@
         vertical-align: middle;
     }
 
-    .formitem_ct{
-        /*line-height: 32px;*/
+    .formitem_ct {
         flex: 1;
+        min-width: 0;
         font-size: $font-size-base;
     }
 


### PR DESCRIPTION
form.item如果设置了labelSize,但是select内容宽度很长时,样式错乱
https://stackoverflow.com/questions/38223879/white-space-nowrap-breaks-flexbox-layout