### PR TITLE
KLTable udpate

### DIFF
--- a/src/js/components/layout/KLTable/TableBody/index.js
+++ b/src/js/components/layout/KLTable/TableBody/index.js
@@ -20,6 +20,8 @@ const TableBody = Component.extend({
     this.supr(data);
     this.$table = this.$parent;
     this.$tableData = this.$parent.data;
+    this.data.$table = this.$table;
+    this.data.$tableData = this.$tableData;
     if (!this.data.fixedCol) {
       this.data.timer = setInterval(() => {
         this._updateItemHeight();

--- a/src/js/components/layout/KLTable/TableBody/index.js
+++ b/src/js/components/layout/KLTable/TableBody/index.js
@@ -63,22 +63,6 @@ const TableBody = Component.extend({
   _expandTr(item, itemIndex, column) {
     item._expanddingColumn = column;
     item.expand = !item.expand;
-    if (column.expandable) {
-      this._updateSubTrHeight(item, itemIndex);
-    }
-  },
-  _updateSubTrHeight(item, itemIndex) {
-    const self = this;
-    const timer = setInterval(() => {
-      const tdElement = self.$refs[`expand${itemIndex}`];
-      if (tdElement && item._expandHeight !== tdElement.clientHeight) {
-        item._expandHeight = tdElement.clientHeight;
-        self.$update();
-      }
-      if (!item.expand) {
-        clearInterval(timer);
-      }
-    }, 100);
   },
   _onSubEvent(type, table, e) {
     this.$emit('subevent', {

--- a/src/js/components/layout/KLTable/TableHeader/index.js
+++ b/src/js/components/layout/KLTable/TableHeader/index.js
@@ -62,6 +62,8 @@ const TableHeader = Component.extend({
     this.supr(data);
     this.$table = this.$parent;
     this.$tableData = this.$parent.data;
+    this.data.$table = this.$table;
+    this.data.$tableData = this.$tableData;
   },
   _onHeaderClick(header, headerIndex) {
     if (!header.sortable) {

--- a/src/js/components/layout/KLTable/index.js
+++ b/src/js/components/layout/KLTable/index.js
@@ -611,12 +611,18 @@ const KLTable = Component.extend({
   .component('table-header', TableHeader)
   .component('table-body', TableBody);
 
-const oldFilterFunc = KLTable.filter;
-
-KLTable.filter = function (...args) {
+const oldFilter = KLTable.filter;
+KLTable.$filter = function (...args) {
   TableHeader.filter(...args);
   TableBody.filter(...args);
-  oldFilterFunc.apply(KLTable, args);
+  oldFilter.apply(KLTable, args);
+};
+KLTable.filter = KLTable.$filter;
+
+KLTable.$component = function (...args) {
+  TableHeader.component(...args);
+  TableBody.component(...args);
+  KLTable.component(KLTable, ...args);
 };
 
 module.exports = KLTable;

--- a/src/js/components/layout/KLTable/index.js
+++ b/src/js/components/layout/KLTable/index.js
@@ -122,7 +122,9 @@ const KLTable = Component.extend({
       self._updateParentWidth();
       self._updateSticky();
       self._updateTableWidth();
+      this._updateExpandHeight();
       self._initWatchers();
+      this.$update();
     }, 0);
     setTimeout(() => {
       self._getHeaderHeight();
@@ -313,7 +315,7 @@ const KLTable = Component.extend({
     });
   },
   _getExpandRowTop(index) {
-    const a = this.data.source.reduce((sum, row, rowIndex) => {
+    const top = this.data.source.reduce((sum, row, rowIndex) => {
       let newSum = sum;
       if (rowIndex <= index) {
         newSum += row._rowHeight;
@@ -324,7 +326,7 @@ const KLTable = Component.extend({
       }
       return sum;
     }, this.data.headerHeight);
-    return a;
+    return top;
   },
   _updateParentWidth() {
     const data = this.data;
@@ -505,7 +507,7 @@ const KLTable = Component.extend({
   },
   _onItemCheckChange(e) {
     /**
-         * @event cKLTable#heckchange 多选事件
+         * @event KLTable#checkchange 多选事件
          * @property {object} sender 事件来源
          * @property {boolean} checked 是否选中
          * @property {object} item 操作对象
@@ -564,11 +566,13 @@ const KLTable = Component.extend({
          * @property {object} sender 事件来源
          * @property {number} current 事件来源
          * @property {object} paging 分页对象
+         * @property {object} pagingEvent Pager 的分页事件
          */
     this.$emit('paging', {
       sender: this,
       current: e.current,
       paging: this.data.paging,
+      pagingEvent: e,
     });
   },
   _onFixedExpand(e) {

--- a/src/js/components/layout/KLTable/index.md
+++ b/src/js/components/layout/KLTable/index.md
@@ -879,7 +879,7 @@ var component = new NEKUI.Component({
 
 由于组件的设计结构比较特殊，表格中表头和内容分别是两个独立的组件，因此　`kl-table` 上挂载的属性无法直接传递到表头和内容当中。
 
-如有需要取得外部的数据，则需要通过 `this.$table.data` 或者 `this.$tableData` 去获取。
+如有需要取得外部的数据，则需要通过 `$table.data` 或者 `$tableData` 去获取。
 
 <div class="m-example"></div>
 
@@ -895,8 +895,8 @@ var component = new NEKUI.Component({
     template: template,
     data: {
         count: 0,
-        thTpl: '{header.name + " :" + this.$tableData.count}',
-        tdTpl: '{item.title + " :" + this.$table.data.count}',
+        thTpl: '{header.name + " :" + $tableData.count}',
+        tdTpl: '{item.title + " :" + $table.data.count}',
         table: {
             source: []
         }

--- a/src/js/components/layout/KLTable/index.md
+++ b/src/js/components/layout/KLTable/index.md
@@ -458,7 +458,10 @@ var component = new NEKUI.Component({
 自定义模版中可以通过 `emit` 的方法向上抛出事件。
 如果模版直接写在`kl-table`当中，这部分模版会被作为footer模版进行渲染。这部分模版不需要进行特殊的字符串处理，并可以直接进行数据绑定。
 
-要在模版中使用自定义的 `filter` 则需要将其先注册到 `NEKUI.KLTable` 上。
+要在模版中使用自定义的 `filter` 则需要通过 `NEKUI.KLTable.$filter` 方法 将其先注册到 `NEKUI.KLTable` 上。
+
+
+要在模版中使用自定义的组件则需要通过 `NEKUI.KLTable.$component` 方法 将其先注册到 `NEKUI.KLTable` 上。
 
 注意：
 1. 内嵌形式的模版需要在每行的两端加上 `{'`、`'}` ，否则模版字符串的插值会无法传递给模版组件，
@@ -492,11 +495,12 @@ var component = new NEKUI.Component({
 
 ```javascript
 var anchor = NEKUI.Component.extend({
-    name: 'anchor',
     template: '<a>&nbsp;anchor</a>',
 });
 
-NEKUI.KLTable.filter('txtFilter', function(val) {
+NEKUI.KLTable.$component('anchor', anchor);
+
+NEKUI.KLTable.$filter('txtFilter', function(val) {
     return val + '*';
 });
 


### PR DESCRIPTION
1. [bufix] expand row throws Error after destroy
2. [feature] paging event contains pagingEvent which come from the original Pager event
3. [feature] rename method filter => $filter, filter method still works
4. [feature] in template string, use $table and $tableData instead of this.$table or this.$tableData to access the actual table instance
5. [feature] add method $component to register component to KLTable and its sub component like TableBody and TableHeader