### PR TITLE
fix select

### DIFF
--- a/src/js/components/form/KLSelect/index.html
+++ b/src/js/components/form/KLSelect/index.html
@@ -35,9 +35,7 @@
 	                    <i class="u-icon u-icon-remove" z-dis={item.disabled} on-click={this.removeSelected(selected,item_index,$event)}></i>
 	                </span>
 				{/list}
-				{#if !open && (!selected || !selected.length)}
-					<span class='m-multi-placeholder'>{placeholder}</span>
-				{/if}
+				<span class='m-multi-placeholder' r-hide={!(!open && (!selected || !selected.length))}>{placeholder}</span>
 	        </div>
 	    {/if}
 	    {#if open}


### PR DESCRIPTION
问题：http://olz3b8fm9.bkt.clouddn.com/17-11-30/54237062.jpg

用的 r-hide 是因为在 dropdown 基类里面会给 dom 绑定一个 click 事件然后判断事件的 $event 是不是这个 dropdown 的子节点，如果不是子节点就将 open 置为 false

如果用 if else 的话触发这个事件的时候节点已经不在了，所以会判断成在 dropdown 外面点击，就会出现展开马上又收起的问题