### PR TITLE
修复上传失败是显示文件列表更新问题

### DIFF
--- a/src/js/components/form/KLUpload/components/UploadBase/index.js
+++ b/src/js/components/form/KLUpload/components/UploadBase/index.js
@@ -196,8 +196,9 @@ const UploadBase = Component.extend({
 
     // 找到该unit单元在fileList中的位置
     const fileIndex = fileList.findIndex(item => uid === item.uid);
-    if (fileIndex === -1) {
+    if (fileIndex === -1 && unit.status === 'success') {
       // fileList中不存在该单元数据，新增数据
+      // 只有当上传成功时才更新fileList
       fileList.push({ name, url, flag, uid });
     } else if (flag === Config.flagMap.DELETED) {
       fileList[fileIndex].flag = Config.flagMap.DELETED;


### PR DESCRIPTION
更新展示文件列表时加了上传状态判断 unit.status === 'success'，只有上传成功时才更新展示列表