### PR TITLE
#323 validationMixin.js 中的bug修复

### DIFF
--- a/src/js/util/validationMixin.js
+++ b/src/js/util/validationMixin.js
@@ -22,7 +22,7 @@ module.exports = function (Component) {
         this.$on('destroy', function () {
           const index = $outer.controls.indexOf(this);
           if (index !== -1) {
-            $outer.controls.splice(index, 1);
+            $outer.controls = $outer.controls.splice(index, 1);
           }
         });
       }


### PR DESCRIPTION
validationMixin.js 中 $outer.controls.splice(index, 1); 不会触发 kl-form 中
this.$watch('this.controls.length', function () { this.initSelectorSource(); this.initFormItem(); }); 的执行