### PR TITLE
fixbug: if kl-form-item else kl-form-item 会导致切换以后 不刷新样式，不获取下拉值 

### DIFF
--- a/src/js/components/form/KLForm/KLFormItem/index.js
+++ b/src/js/components/form/KLForm/KLFormItem/index.js
@@ -36,13 +36,12 @@ const KLFormItem = Validation.extend({
   },
   init() {
     const parentValidator = this._parentValidator;
-    this.$watch('this.controls.length', (newValue, oldValue) => {
-      /* 处理kl-form-item下面kl-select数量变化的情况,当从没有变为有时,需要赋值 */
-      if (oldValue === undefined) {
-        return;
-      }
+    this.$watch('this.controls.length', () => {
       if (parentValidator && parentValidator.initSelectorSource) {
         parentValidator.initSelectorSource();
+      }
+      if (parentValidator && parentValidator.initFormItem) {
+        parentValidator.initFormItem();
       }
     });
 

--- a/src/js/components/form/KLForm/index.js
+++ b/src/js/components/form/KLForm/index.js
@@ -58,6 +58,8 @@ const KLForm = Validation.extend({
       this.initSelectorSource();
       this.initFormItem();
     });
+
+    this.__reqSourceOnce = _.debounce(this.__reqSource.bind(this), 200, false);
   },
   initFormItem() {
     const controls = this.controls;
@@ -85,8 +87,7 @@ const KLForm = Validation.extend({
     if (!this.data.service || !this.selectors.length) {
       return;
     }
-
-    this.__reqSource();
+    this.__reqSourceOnce();
   },
   __getSourceKeys() {
     return this.selectors.map($formitem => $formitem.data.sourceKey);

--- a/src/js/util/validationMixin.js
+++ b/src/js/util/validationMixin.js
@@ -22,7 +22,7 @@ module.exports = function (Component) {
         this.$on('destroy', function () {
           const index = $outer.controls.indexOf(this);
           if (index !== -1) {
-            $outer.controls = $outer.controls.splice(index, 1);
+            $outer.controls.splice(index, 1);
           }
         });
       }


### PR DESCRIPTION
```html
{#if isEdit}
<kl-form-item required title="货源地：" sourceKey="goodsSource">
        <kl-select message="请选择货源地" value={goodsVersion.goodsSourceCode}></kl-select>
</kl-form-item>
{#else}
<kl-form-item title="货源地：">
    {goodsVersion.goodsChannel}
</kl-form-item>
{/if}
```

上述代码，isEdit 默认为 false，切换以后，kl-form不会自动发送获取下拉的请求。