### PR TITLE
解决kl-tree-view不能配置nameKey问题

### DIFF
--- a/src/js/components/form/KLTreeView/index.html
+++ b/src/js/components/form/KLTreeView/index.html
@@ -1,3 +1,3 @@
 <div class="m-treeview {class}" r-class={ {'m-multitreeview': multiple} } z-dis={disabled} r-hide={!visible}>
-	<tree-view-list source={source} childKey={childKey} visible multiple={multiple} value={value} on-setselected={this.setSelected($event)} />
+	<tree-view-list source={source} childKey={childKey} nameKey={nameKey} visible multiple={multiple} value={value} on-setselected={this.setSelected($event)} />
 </div>

--- a/src/js/components/form/KLTreeView/index.js
+++ b/src/js/components/form/KLTreeView/index.js
@@ -15,6 +15,7 @@ require('../common/TreeViewList');
  * @param {object[]}  [options.data.source=[]]                <=> 数据源
  * @param {string}    [options.data.source[].name]            => 每项的内容
  * @param {string}    [options.data.key=id]                   => 数据项的键
+ * @param {string}    [options.data.nameKey=name]             => 数据项的显示值
  * @param {string}    [options.data.childKey=children]        => 数据子项的键
  * @param {boolean}   [options.data.source[].open=false]      => 此项为展开/收起状态
  * @param {boolean}   [options.data.source[].checked=false]   => 选中此项

--- a/src/js/components/form/KLTreeView/index.md
+++ b/src/js/components/form/KLTreeView/index.md
@@ -52,13 +52,13 @@ var component = new NEKUI.Component({
 ```xml
 <kl-form>
     <kl-col span=6>
-        <kl-tree-view  source={source} selected={selected} />
+        <kl-tree-view  source={source} nameKey='value' selected={selected} />
     </kl-col>
     <kl-col span=6>
-        <kl-tree-view  source={source} value={value} />
+        <kl-tree-view  source={source} nameKey='value' value={value} />
     </kl-col>
 </kl-form>
-<p>选择的分别是是: {selected.name} {value}</p>
+<p>选择的分别是是: {selected.value} {value}</p>
 ```
 
 ```javascript
@@ -66,9 +66,9 @@ var component = new NEKUI.Component({
     template: template,
     data: {
         source: [
-            {id: 1, name: '母婴儿童'},
-            {id: 2, name: '美容彩妆'},
-            {id: 3, name: '服饰鞋包'}
+            {id: 1, value: '母婴儿童'},
+            {id: 2, value: '美容彩妆'},
+            {id: 3, value: '服饰鞋包'}
         ]
     },
     config: function() {

--- a/src/js/components/form/common/TreeViewList/index.html
+++ b/src/js/components/form/common/TreeViewList/index.html
@@ -8,9 +8,9 @@
 			{#if multiple && !item.divider}
 			<kl-check checked={item.checked} on-check={this.check()} disabled={item.disabled} on-change={this._onItemCheckedChange($event, item)} />
 			{/if}
-			<div class="treeview_itemname" z-sel={this.$ancestor.data.multiple ? item.selected : this.$ancestor.data.selected === item} z-dis={item.disabled} title={item.name} z-divider={item.divider} on-click={this.select(item)}>{#if @(itemTemplate)}{#inc @(itemTemplate)}{#else}{item.name}{/if}</div>
+			<div class="treeview_itemname" z-sel={this.$ancestor.data.multiple ? item.selected : this.$ancestor.data.selected === item} z-dis={item.disabled} title={item[nameKey]} z-divider={item.divider} on-click={this.select(item)}>{#if @(itemTemplate)}{#inc @(itemTemplate)}{#else}{item[nameKey]}{/if}</div>
 		</div>
-		{#if item.childrenCount || (item.children && item.children.length)}<tree-view-list childKey={childKey} source={item.children} visible={item.open} parent={item} multiple={multiple} on-setselected={this._setSelected($event)} />{/if}
+		{#if item.childrenCount || (item.children && item.children.length)}<tree-view-list childKey={childKey} nameKey={nameKey} source={item.children} visible={item.open} parent={item} multiple={multiple} on-setselected={this._setSelected($event)} />{/if}
 	</li>
 	{/list}
 </ul>


### PR DESCRIPTION
kl-tree-view的namekey不可配，导致使用时只能用固定的数据格式。现改为namekey可配置，需要将tree-view-list中的显示修改。