### PR TITLE
when date is string/number, date.getMonth will wrong

### DIFF
--- a/src/js/components/form/KLDatePicker/Calendar/index.js
+++ b/src/js/components/form/KLDatePicker/Calendar/index.js
@@ -147,8 +147,8 @@ const Calendar = Component.extend({
   _update() {
     this.data._days = [];
     const date = this.data.date;
-    const month = date.getMonth();
     const mfirst = new Date(date);
+    const month = mfirst.getMonth();
     mfirst.setDate(1);
     const mfirstTime = +mfirst;
     const nfirst = new Date(mfirst);


### PR DESCRIPTION
maxDate 中传的 值为时间戳的时候，会导致 date.getMonth 报错。外部使用的时候maxDate 只能是date 类型。需要放宽这个限制，可以传入时间戳