### PR TITLE
fixbug: kl-tabs设置selected属性报错

### DIFF
--- a/src/js/components/navigation/KLTabs/index.js
+++ b/src/js/components/navigation/KLTabs/index.js
@@ -50,7 +50,7 @@ const KLTabs = Component.extend({
       this.$emit('change', {
         sender: this,
         selected: newValue,
-        key: newValue.data.key,
+        key: newValue.key,
       });
     });
   },


### PR DESCRIPTION
```js
<kl-tabs on-change={this.tabChange($event)} selected={{key: 1}}>
    <kl-tab title="Tab1" key=0>Content1</kl-tab>
    <kl-tab title="Tab2" key=1>Content2</kl-tab>
</kl-tabs>
```

报错：can't read 'key' of undefined.