### PR TITLE
 #fix: 获取refs时没有判空 

### DIFF
--- a/src/js/components/layout/KLTable/index.js
+++ b/src/js/components/layout/KLTable/index.js
@@ -215,6 +215,7 @@ const KLTable = Component.extend({
     }
   },
   _getTableWrapOffset() {
+    if(!this.$refs) return;
     const scrollParentNode = this._getScrollParentNode();
     let parentRect = {
       top: 0,
@@ -380,11 +381,13 @@ const KLTable = Component.extend({
     this.$update('_dataColumns', u.getLeaves(this.data.columns));
   },
   _getHeaderHeight() {
+    if(!this.$refs) return;
     const headerHeight = u.getElementHeight(this.$refs.headerWrap);
     this._updateData('headerHeight', headerHeight);
     return headerHeight;
   },
   _getFooterHeight() {
+    if(!this.$refs) return;
     const footerHeight = u.getElementHeight(this.$refs.footerWrap);
     this._updateData('footerHeight', footerHeight);
     return footerHeight;


### PR DESCRIPTION
tab快速切换时table报错，节点已经注销了去获取会报null：[codepen](https://codepen.io/coldq/pen/ZMNgrg)。
增加判空。