### PR TITLE
kl-table左侧固定列后，鼠标滚动只能滚右边部分，这样每行左右数据就对不上 了

### DIFF
--- a/src/js/components/layout/KLTable/index.html
+++ b/src/js/components/layout/KLTable/index.html
@@ -131,7 +131,7 @@
             }} />
 
         <div ref="bodyWrapFixedLeft"
-            class="kl-table__body"
+            class="kl-table__body kl-table-fixed__body"
             r-style={{
                 width: fixedTableWidth + 'px',
                 'max-height': bodyHeight == undefined ? 'auto' : bodyHeight - scrollXBarWidth + 'px'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13317454/68101679-d1bb1c80-ff09-11e9-9f05-764d285d4ac3.png)
